### PR TITLE
Update to be compliant with React 0.14.3.

### DIFF
--- a/lib/components/Carousel.js
+++ b/lib/components/Carousel.js
@@ -1,7 +1,6 @@
 'use strict';
 
-/** @jsx React.DOM */
-var React = require('react/addons'),
+var React = require('react'),
 	klass = require('../cssClasses'),
 	_ = require('lodash'),
 	outerWidth = require('../dimensions').outerWidth,
@@ -55,7 +54,7 @@ module.exports = React.createClass({displayName: "exports",
 
 		window.removeEventListener("resize", this.resizeWrapper);
 		for (index; index >= 0; index -= 1) {
-			this.refs['item' + index].getDOMNode().onload = null;
+			this.refs['item' + index].onload = null;
 		}
   },
 	componentWillReceiveProps: function(props) {
@@ -78,7 +77,7 @@ module.exports = React.createClass({displayName: "exports",
 			image;
 
 		for (index; index >= 0; index -= 1) {
-			image = this.refs['item' + index].getDOMNode();
+			image = this.refs['item' + index];
 
 			if (!!image.src && image.complete) { // image is loaded
 				maxImageWidth = Math.max(outerWidth(image), maxImageWidth);
@@ -118,29 +117,24 @@ module.exports = React.createClass({displayName: "exports",
 		}
 	},
 	loadImage: function(index) {
-		var imageReactElement = _.get(this, 'refs[item' + index + ']'),
-			loadedImages,
-			image;
+		var image = _.get(this, 'refs[item' + index + ']'),
+			loadedImages;
 
-		if (imageReactElement) {
-			image = imageReactElement.getDOMNode();
+		if (image && !image.src) {
+			image.src = this.props.images[index].src;
 
-			if (!image.src) {
-				image.src = this.props.images[index].src;
-
-				if (index === this.state.selectedImage && this.isSlider()) {
-					this.getImageDimensionsBeforeOnload(index); // for first image, we want to get height/width ASAP
-				}
-
-				loadedImages = this.state.loadedImages.slice();
-				loadedImages[index] = true;
-				this.setState({
-					loadedImages: loadedImages
-				});
-
-				_.defer(this.loadImage, index + 1);
-				_.defer(this.loadImage, index - 1);
+			if (index === this.state.selectedImage && this.isSlider()) {
+				this.getImageDimensionsBeforeOnload(index); // for first image, we want to get height/width ASAP
 			}
+
+			loadedImages = this.state.loadedImages.slice();
+			loadedImages[index] = true;
+			this.setState({
+				loadedImages: loadedImages
+			});
+
+			_.defer(this.loadImage, index + 1);
+			_.defer(this.loadImage, index - 1);
 		}
 	},
 	onImageLoad: function(e) {
@@ -150,29 +144,25 @@ module.exports = React.createClass({displayName: "exports",
 		}
 	},
 	getImageDimensionsBeforeOnload: function(index) {
-		var imageReactElement,
-			image,
+		var image,
 			interval;
 
 		if (!this.isSlider()) {
 			return;
 		}
 
-		imageReactElement = _.get(this, 'refs[item' + index + ']');
-		if (imageReactElement) {
-			image = imageReactElement.getDOMNode();
+		image = _.get(this, 'refs[item' + index + ']');
 
-			if (image.src && !image.complete) {
-				interval = window.setInterval(function() {
-					if (image.offsetWidth) {
-						this.setMaxImageWidth(outerWidth(image));
-						window.clearInterval(interval);
-					}
-				}.bind(this), 20);
+		if (image && image.src && !image.complete) {
+			interval = window.setInterval(function() {
+				if (image.offsetWidth) {
+					this.setMaxImageWidth(outerWidth(image));
+					window.clearInterval(interval);
+				}
+			}.bind(this), 20);
 
-				// Give up after awhile so we don't drain user's battery
-				window.setTimeout(function() { window.clearInterval(interval); }, 2000);
-			}
+			// Give up after awhile so we don't drain user's battery
+			window.setTimeout(function() { window.clearInterval(interval); }, 2000);
 		}
 	},
 	resizeWrapper: function() {
@@ -181,7 +171,7 @@ module.exports = React.createClass({displayName: "exports",
 			image;
 
 		for (index; index >= 0; index -= 1) {
-			image = this.refs['item' + index].getDOMNode();
+			image = this.refs['item' + index];
 
 			if (image.complete) { // image is loaded
 				maxImageWidth = Math.max(outerWidth(image), maxImageWidth);
@@ -239,7 +229,7 @@ module.exports = React.createClass({displayName: "exports",
 			// adding it to the last position and saving the position
 			this.touchPosition = delta;
 
-			var elementStyle = this.refs.itemList.getDOMNode().style;
+			var elementStyle = this.refs.itemList.style;
 
 			// if 3d isn't available we will use left to move
 			if (has3d) {

--- a/lib/components/ImageGallery.js
+++ b/lib/components/ImageGallery.js
@@ -1,7 +1,6 @@
 'use strict';
 
-/** @jsx React.DOM */
-var React = require('react/addons');
+var React = require('react');
 var Carousel = require('./Carousel');
 
 module.exports = React.createClass({displayName: "exports",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-responsive-carousel",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "React Responsive Carousel",
   "author": {
   "name": "Leandro Augusto Lemos",

--- a/lib/package.json
+++ b/lib/package.json
@@ -33,6 +33,6 @@
     "lodash": "~3.8.0"
   },
   "devDependencies": {
-    "react": "^0.13.1"
+    "react": "^0.14.3"
   }
 }


### PR DESCRIPTION
The main change is that `getDOMNode` should no longer be called for `refs` that are DOM elements.
