### PR TITLE
Update for React 15

### DIFF
--- a/lib/components/Carousel.js
+++ b/lib/components/Carousel.js
@@ -23,7 +23,7 @@ module.exports = React.createClass({displayName: "exports",
 			showArrows: true,
 			carouselWidth: 0,
 			// Carousel is the default type. It stands for a group of thumbs.
-			// It also accepts 'slider', which will show a full width item 
+			// It also accepts 'slider', which will show a full width item
 			type: 'carousel'
 		}
 	},
@@ -44,7 +44,7 @@ module.exports = React.createClass({displayName: "exports",
 	},
 	componentWillMount: function() {
 		if (typeof window !== 'undefined') {
-			// as the widths are calculated, we need to resize 
+			// as the widths are calculated, we need to resize
 			// the carousel when the window is resized
 			window.addEventListener("resize", this.resizeWrapper);
 		}
@@ -201,7 +201,7 @@ module.exports = React.createClass({displayName: "exports",
 	onSwipeStart: function (e) {
 		if (e.touches.length === 1) {
 			this.setState({
-				// saving the initial touch 
+				// saving the initial touch
 				touchStart: e.touches[0].pageX,
 				// setting the swiping state
 				swiping: true
@@ -256,9 +256,9 @@ module.exports = React.createClass({displayName: "exports",
 				touchStart: null,
 				// finish the swiping state
 				swiping: false
-			}, 
+			},
 				// this function is the callback of setState because we need to wait for the
-				// state to be setted, so the swiping class will be removed and the 
+				// state to be setted, so the swiping class will be removed and the
 				// transition to the next slide will be smooth
 				function () {
 	        if (this.touchPosition === 0) {
@@ -274,7 +274,7 @@ module.exports = React.createClass({displayName: "exports",
 	          this.slideRight();
 	        }
 					// discard the position
-					this.touchPosition = null;	
+					this.touchPosition = null;
 				}.bind(this)
 			);
 		}
@@ -298,12 +298,12 @@ module.exports = React.createClass({displayName: "exports",
 
 	moveTo: function(position) {
 		position = (position + this.props.images.length) % this.props.images.length;
-		
+
 		this.setState({
 			// if it's not a slider, we don't need to set position here
 			selectedImage: this.isSlider() ? position : this.state.selectedImage
 		});
-		
+
 		this.triggerOnSelectImage(position);
 	},
 
@@ -324,35 +324,35 @@ module.exports = React.createClass({displayName: "exports",
 			var itemClass = klass.ITEM(this.isSlider(), index, this.state.selectedImage),
 				styles = this.isSlider() ? { width: this.state.maxImageWidth } : {},
 				imageTag;
-			
+
 			if (this.isImageLoaded(index)) {
 				imageTag = (
-					React.createElement("img", React.__spread({key: index, ref: "item" + index},  item))
+					React.createElement("img", Object.assign({key: index, ref: "item" + index},  item))
 				);
 			} else {
 				imageTag = (
-					React.createElement("img", React.__spread({key: index, ref: "item" + index},  _.omit(item, 'src')))
+					React.createElement("img", Object.assign({key: index, ref: "item" + index},  _.omit(item, 'src')))
 				);
 			}
 
 			return (
-				React.createElement("li", {key: index, className: itemClass, 
-					style: styles, 
-					onClick: this.triggerOnSelectImage.bind(this, index)}, 
+				React.createElement("li", {key: index, className: itemClass,
+					style: styles,
+					onClick: this.triggerOnSelectImage.bind(this, index)},
 					imageTag
 				)
 			);
 		}.bind(this));
-					
+
 	},
 
 	renderDots: function() {
 		if (!this.props.showDots) {
 			return null
 		}
-		
+
 		return (
-			React.createElement("ul", {className: "control-dots"}, 
+			React.createElement("ul", {className: "control-dots"},
 				this.props.images.map( function(item, index)  {
 					return React.createElement("li", {className: klass.DOT(index === this.state.selectedImage), onClick: this.changeItem, value: index, key: index});
 				}.bind(this))
@@ -365,7 +365,7 @@ module.exports = React.createClass({displayName: "exports",
 			return null
 		}
 		return React.createElement("p", {className: "carousel-status"}, this.state.selectedImage + 1, " of ", this.props.images.length);
-	}, 
+	},
 
 	render: function() {
 		var showArrows = this.props.showArrows && (this.numVisibleItems() / 2) < this.props.images.length,
@@ -379,7 +379,7 @@ module.exports = React.createClass({displayName: "exports",
 		if (this.props.images.length === 0) {
 			return null;
 		}
-		
+
 		// hold the last position in the component context to calculate the delta on swiping
 		this.currentPosition = (this.state.wrapperWidth - this.state.maxImageWidth) / 2 - (this.state.maxImageWidth * this.state.selectedImage);
 
@@ -413,22 +413,22 @@ module.exports = React.createClass({displayName: "exports",
 		}
 
 		return (
-			React.createElement("div", {className: klass.CAROUSEL(this.isSlider(), this.state.animate)}, 
-				prevArrow, 
-				
-				React.createElement("div", {className: klass.WRAPPER(this.isSlider()), ref: "itemsWrapper", style: { width: this.state.wrapperWidth}}, 
-					React.createElement("ul", {className: klass.SLIDER(this.isSlider(), this.state.swiping), style: itemListStyles, ref: "itemList", onTouchStart: this.onSwipeStart, onTouchMove: this.onSwipeMove, onTouchEnd: this.onSwipeEnd}, 
-						 this.renderImages() 
-					)
-				), 
+			React.createElement("div", {className: klass.CAROUSEL(this.isSlider(), this.state.animate)},
+				prevArrow,
 
-				nextArrow, 
-				
-				 this.renderDots(), 
-				 this.renderStatus() 
+				React.createElement("div", {className: klass.WRAPPER(this.isSlider()), ref: "itemsWrapper", style: { width: this.state.wrapperWidth}},
+					React.createElement("ul", {className: klass.SLIDER(this.isSlider(), this.state.swiping), style: itemListStyles, ref: "itemList", onTouchStart: this.onSwipeStart, onTouchMove: this.onSwipeMove, onTouchEnd: this.onSwipeEnd},
+						 this.renderImages()
+					)
+				),
+
+				nextArrow,
+
+				 this.renderDots(),
+				 this.renderStatus()
 			)
 		);
-		
+
 	}
 });
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-responsive-carousel",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "React Responsive Carousel",
   "author": {
   "name": "Leandro Augusto Lemos",
@@ -33,6 +33,6 @@
     "lodash": "3.10.1"
   },
   "devDependencies": {
-    "react": "^0.14.3"
+    "react": "^0.14.3 || ^15.0.0"
   }
 }

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-responsive-carousel",
+  "name": "@massdrop/react-responsive-carousel",
   "version": "1.1.2",
   "description": "React Responsive Carousel",
   "author": {


### PR DESCRIPTION
Remove use of React.__spread which has now been deprecated. See https://facebook.github.io/react/blog/2016/04/08/react-v15.0.1.html for reference.
In addition, rename package `@massdrop/react-responsive-carousel`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/massdrop/react-responsive-carousel/3)

<!-- Reviewable:end -->
